### PR TITLE
Configure transform-react-jsx via .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,6 @@
         "stage-1"
     ],
     "plugins": [
-        "transform-react-jsx"
+        ["transform-react-jsx", { pragma: 'ssml' }]
     ]
 }

--- a/test/renderToString-test.js
+++ b/test/renderToString-test.js
@@ -1,5 +1,3 @@
-/** @jsx ssml */
-
 import { ssml } from '../src/ssml';
 import { renderToString } from '../src/renderToString';
 

--- a/test/ssml-test.js
+++ b/test/ssml-test.js
@@ -1,5 +1,3 @@
-/** @jsx ssml */
-
 import { ssml } from '../src/ssml';
 import { renderToString } from '../src/renderToString';
 

--- a/test/tags-test.js
+++ b/test/tags-test.js
@@ -1,5 +1,3 @@
-/** @jsx ssml */
-
 import { ssml } from '../src/ssml';
 import { renderToString } from '../src/renderToString';
 


### PR DESCRIPTION
Parameters can be passed to `transform-react-jsx` in `.babelrc` instead of requiring each usage of SSML needing to include the `@jsx ssml` pragma comment.
