### PR TITLE
Configure transform-react-jsx via .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,6 @@
         "stage-1"
     ],
     "plugins": [
-        ["transform-react-jsx", { pragma: 'ssml' }]
+        ["transform-react-jsx", { "pragma": "ssml" }]
     ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,6 @@
         "stage-1"
     ],
     "plugins": [
-        "transform-react-jsx"
+        ["transform-react-jsx", { pragma: 'ssml' }]
     ]
 }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Manipulate and validate the [subset of SSML](https://developer.amazon.com/public
 ### Example
 
 ```js
-/** @jsx ssml */
-
 import { ssml, renderToString } from 'alexa-ssml';
 
 const tags = (
@@ -31,8 +29,6 @@ const raw = renderToString(tags);
 ### Custom Elements
 
 ```js
-/** @jsx ssml */
-
 import { ssml } from 'alexa-ssml';
 
 function LongPause(props) {
@@ -51,9 +47,21 @@ const data = (
 
 ##### `ssml(tag, props, ...children) -> object`
  * `tag` can be  a string or function
- * Use `/** @jsx ssml */` to support jsx syntax
  * Returns object like `{ tag, props, children }`
 
 ##### `renderToString(data) -> string`
  * Takes in object from `ssml` function
  * Must be wrapped in a `"speak"` tag
+
+
+### JSX Syntax
+
+To use SSML JSX syntax directly in JavaScript add `/** @jsx ssml */` to the top of the file or configure `transform-react-jsx` using `.babelrc`:
+
+```json
+{
+    "plugins": [
+        ["transform-react-jsx", { "pragma": "ssml" }]
+    ]
+}
+```

--- a/test/renderToString-test.js
+++ b/test/renderToString-test.js
@@ -1,5 +1,3 @@
-/** @jsx ssml */
-
 import { ssml } from '../src/ssml';
 import { renderToString } from '../src/renderToString';
 

--- a/test/ssml-test.js
+++ b/test/ssml-test.js
@@ -1,5 +1,3 @@
-/** @jsx ssml */
-
 import { ssml } from '../src/ssml';
 import { renderToString } from '../src/renderToString';
 

--- a/test/tags-test.js
+++ b/test/tags-test.js
@@ -1,5 +1,3 @@
-/** @jsx ssml */
-
 import { ssml } from '../src/ssml';
 import { renderToString } from '../src/renderToString';
 


### PR DESCRIPTION
Parameters can be passed to `transform-react-jsx` in `.babelrc` instead of requiring each usage of SSML needing to include the `@jsx ssml` pragma comment.
