### PR TITLE
Allow options to be passed to renderToString

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 node_modules
-src
 scripts
 .gitignore
 .babelrc

--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   "bugs": {
     "url": "http://github.com/nickclaw/alexa-ssml/issues"
   },
-  "files": [
-    "lib",
-    "src"
-  ],
   "keywords": [
     "alexa",
     "skills",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.2",
   "description": "JSX for Alexa Skills Kit SSML",
   "main": "lib/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "build": "rm -rf lib && babel src --out-dir lib",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "bugs": {
     "url": "http://github.com/nickclaw/alexa-ssml/issues"
   },
+  "files": [
+    "lib",
+    "src"
+  ],
   "keywords": [
     "alexa",
     "skills",

--- a/src/renderToString.js
+++ b/src/renderToString.js
@@ -40,7 +40,7 @@ function renderNode(children, node) {
  * @param {Object} data
  * @return {String}
  */
-export default function renderToString(data) {
+export default function renderToString(data, pretty = false) {
     const rootTag = get(data, 'tag');
     if (rootTag !== 'speak') {
         throw new Error(`SSML must start with a 'speak' tag, currently '${rootTag}'`);
@@ -52,5 +52,5 @@ export default function renderToString(data) {
     });
     renderNode(data.children, xml);
 
-    return xml.end({ pretty: true });
+    return xml.end({ pretty });
 }

--- a/src/renderToString.js
+++ b/src/renderToString.js
@@ -40,7 +40,7 @@ function renderNode(children, node) {
  * @param {Object} data
  * @return {String}
  */
-export default function renderToString(data, pretty = false) {
+export default function renderToString(data, options = {}) {
     const rootTag = get(data, 'tag');
     if (rootTag !== 'speak') {
         throw new Error(`SSML must start with a 'speak' tag, currently '${rootTag}'`);
@@ -52,5 +52,5 @@ export default function renderToString(data, pretty = false) {
     });
     renderNode(data.children, xml);
 
-    return xml.end({ pretty });
+    return xml.end(options);
 }

--- a/test/ssml-test.js
+++ b/test/ssml-test.js
@@ -11,7 +11,7 @@ describe('ssml', function() {
 
             const data = <speak><Date format="ymd" /></speak>;
             const string = renderToString(data);
-            expect(string).to.contain('<say-as interpret-as="date" format="ymd"/>\n');
+            expect(string).to.contain('<say-as interpret-as="date" format="ymd"/>');
         });
 
         it('should throw if invalid elements are returned', function() {


### PR DESCRIPTION
Currently calling `renderToString` pretty prints SSML within the string. This causes inconsistencies when testing because the output isn't what the developer expected. This branch makes pretty printing optional and disabled by default.
